### PR TITLE
[1일차] 신현국_BOJ_1018_체스판다시칠하기

### DIFF
--- a/day1/BOJ_1018_체스판다시칠하기/BOJ_1018_체스판다시칠하기_신현국.java
+++ b/day1/BOJ_1018_체스판다시칠하기/BOJ_1018_체스판다시칠하기_신현국.java
@@ -1,0 +1,100 @@
+package algobbusy.bj.ps1018;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static char[][] map;
+	static int maxWCnt, maxHCnt;
+	static int answer = Integer.MAX_VALUE;
+
+	public static void main(String[] args) throws IOException {
+
+		System.setIn(new FileInputStream("./src/algobbusy/bj/ps1018/input.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		// 체스판
+		map = new char[N][M];
+		
+		// NxM 체스판 생성
+		for(int i=0; i<N; i++) {
+			String s = br.readLine();
+			map[i] = s.toCharArray();
+		}
+		
+		// 8x8 subset
+		for(int i=0; i<N-7; i++) {
+			for(int j=0; j<M-7; j++) {
+				search(i, j);
+			}
+		}
+		
+		// 정답 출력
+		answer = 64 - Math.max(maxWCnt, maxHCnt);
+		System.out.println(answer);
+		
+	}
+	
+	public static void search(int i, int j) {
+		
+		int WCnt=0, HCnt=0;
+		char[] colorCheck = {'W', 'B'};
+		int toggleIdx = 0;
+		
+		for(int r=i; r<i+8; r++) {
+			
+			for(int c=j; c<j+8; c++) {
+				// WBWBWBWB 카운트
+				if(map[r][c] == colorCheck[toggleIdx%2]) WCnt++;
+				
+				// BWBWBWBW 카운트
+				if(map[r][c] == colorCheck[++toggleIdx%2]) HCnt++; 
+			}
+			toggleIdx++;
+		}
+		
+		if(WCnt > maxWCnt) maxWCnt = WCnt;
+		if(HCnt > maxHCnt) maxHCnt = HCnt;
+		
+		
+	}
+	
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
1. NxM 체스판에서 8x8로 탐색이 가능한 부분 완전 탐색 진행
2. 8x8 체스판의 왼쪽 상단이 'W' 시작하는 W case와 'B'로 시작하는 B case에 대해 탐색 진행
3. 완전 탐색으로 각 경우의 max 카운트를 저장
4. 64(8x8)에서 W case와 B case 중에 더 큰 값을 빼면 정답 도출