### PR TITLE
[3일차] 김선후_BOJ_월말평가대비_2

### DIFF
--- a/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_김선후.java
+++ b/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_김선후.java
@@ -1,0 +1,52 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_14696 {
+	//딱지놀이
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	
+	public static void main(String[] args) throws Exception {
+		int T = Integer.parseInt(in.readLine());
+		round: for (int tc = 1; tc <= T; tc++) {
+			//딱지의 갯수 저장
+			int[] cardA = new int[101];
+			int[] cardB = new int[101];
+			//a의 딱지
+			stk = new StringTokenizer(in.readLine());
+			int temp = Integer.parseInt(stk.nextToken());
+			for (int j = 0; j < temp; j++) {
+				cardA[Integer.parseInt(stk.nextToken())]++;
+			}
+			//b의 딱지
+			stk = new StringTokenizer(in.readLine());
+			temp = Integer.parseInt(stk.nextToken());
+			for (int j = 0; j < temp; j++) {
+				cardB[Integer.parseInt(stk.nextToken())]++;
+			}
+			//뒤에서 부터 딱지갯수 체크
+			for (int k = 100; k > 0; k--) {
+				if (cardA[k] > cardB[k]) {
+					sb.append("A").append("\n");
+					continue round;
+				} else if (cardA[k] < cardB[k]) {
+					sb.append("B").append("\n");
+					continue round;
+				}
+			}
+			//무승부
+			sb.append("D").append("\n");
+		}
+		out.write(sb.toString());
+		in.close();
+		out.flush();
+		out.close();
+	}
+}

--- a/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_김선후.java
+++ b/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_김선후.java
@@ -1,0 +1,68 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.StringTokenizer;
+
+public class Java_2477 {
+	//참외밭
+	/*fail
+	 * 북쪽 4번과 남쪽 3번은 y배열, 높이배열에 값을 저장해두고,
+	 * 서쪽 2번과 동쪽 1번은 x배열, 가로배열에 값을 저장해둔다.
+	 * 높이배열과 가로배열을 오름차순 혹은 내림차순으로 정렬한후 
+	 * (max높이*max가로) - (min높이 * min가로)를 하면 참외밭의 넓이가 나온다.
+	 * 넓이 * 참외밭 1m^2당 참외수를 곱하면 총 참외수가 나온다.
+	 * 
+	 * 정답풀이
+	 * 각 변의 인덱스 0,1,2,3,4,5를 받고
+	 * i번인덱스의 변*i+1의인덱스의 변의 각 사각형을 구한다.
+	 * 사각형중 가장 큰 넓이를 지는것을 전체넓이로 두고
+	 * 전체 사각형을 제외하고 각 사각형들의 총합은 구해야하는 넓이*3+파인부분의 넓이가 된다
+	 * 즉 전체사각형 - ((3*전체사각형)-각 사각형의 총합)을 해주면 굳이 각 변의 위치값이 필요없다.
+	 * 최종결과는 위에서 나온값에 참외수를 곱하면 된다.
+	 */
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb = new StringBuilder();
+	static int N, ans;
+	static ArrayList<Integer> hwList, sumList;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N=Integer.parseInt(in.readLine());
+		hwList = new ArrayList<>();
+		sumList = new ArrayList<>();
+		for(int i=0; i<6; i++) {
+			stk = new StringTokenizer(in.readLine());
+			int dir = Integer.parseInt(stk.nextToken());
+			hwList.add(Integer.parseInt(stk.nextToken()));
+		}
+		calc();
+		sb.append(ans);
+		out.write(sb.toString());
+		in.close();
+		out.flush();
+		out.close();
+	}
+	private static void calc() {
+		int max_squre=0;
+		int sum=0;
+		for(int i=0; i<hwList.size(); i++) {
+			if(i==hwList.size()-1) sumList.add(hwList.get(i)*hwList.get(0));
+			else sumList.add(hwList.get(i)*hwList.get(i+1));
+		}
+		Collections.sort(sumList);
+//		System.out.println(sumList);
+		max_squre = sumList.get(sumList.size()-1);
+//		System.out.println(max_squre);
+		for(int i=0; i<sumList.size(); i++) {
+			sum+=sumList.get(i);
+		}
+//		System.out.println(max_squre*3+" "+sum);
+		ans =  (max_squre - ((max_squre*3)-sum))*N;
+	}
+}

--- a/day3/BOJ_2491_수열/BOJ_2491_수열_김선후.java
+++ b/day3/BOJ_2491_수열/BOJ_2491_수열_김선후.java
@@ -1,0 +1,56 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_2491 {
+	// 수열
+	/*
+	 * 수열을 담을 배열 혹은 리스트를 담고 
+	 * 현재인덱스의 값과 다음인덱스의 값이 >=, <관계 즉 내림차순일 때 정답값++, 혹은 1로 초기화
+	 * 오름차순일 때는 <=, > 관계 일때 정답값++, 혹은 1로 초기화 
+	 * 내림차순 오름차순을 각각 반복한 뒤에 최대 정닶값을 찾는다.
+	 */
+	
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb = new StringBuilder();
+	static int N;
+	static int[] BigSmall, suyeol;
+	static int ans = Integer.MIN_VALUE;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		suyeol=new int[N];
+		BigSmall=new int[N];
+		stk=new StringTokenizer(in.readLine());
+		for(int i=0; i<N; i++) {
+			suyeol[i]=Integer.parseInt(stk.nextToken());
+		}
+		BigSmall[0]=1;
+		for(int i=1; i<N; i++) {
+			if(suyeol[i-1]<=suyeol[i]) {
+				BigSmall[i] = BigSmall[i-1]+1;
+			}
+			else BigSmall[i]=1;
+		}
+		for(int i=0; i<N; i++) ans=Math.max(ans, BigSmall[i]);
+		for(int i=1; i<N; i++) {
+			if(suyeol[i-1]>=suyeol[i]) {
+				BigSmall[i] = BigSmall[i-1]+1;
+			}
+			else BigSmall[i]=1;
+		}
+		for(int i=0; i<N; i++) ans=Math.max(ans, BigSmall[i]);
+		sb.append(ans);
+		out.write(sb.toString());
+		in.close();
+		out.flush();
+		out.close();
+	}
+
+}

--- a/day3/BOJ_2669_직사각형네개의합집합면적구하기/BOJ_2669_직사각형네개의합집합면적구하기_김선후.java
+++ b/day3/BOJ_2669_직사각형네개의합집합면적구하기/BOJ_2669_직사각형네개의합집합면적구하기_김선후.java
@@ -1,0 +1,56 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_2669 {
+	//직사각형 네개의 합집합의 면적 구하기
+	/*
+	 * 예전에 과제에서 풀었던 색종이 문제의 용응문제라고 생각했고 풀었음.
+	 * 시작 x,y 좌표를 끝 x,y좌표에서 빼주면 가로와 세로의 길이를 구할수 있다.
+	 * 1~100까지의 좌표를 담을수 있도록 int[101][101]의 종이 2차원 배열을 만들고 
+	 * 그 안에 시작 y,x좌표를 초기값으로 두고 가로와 세로길이만큼 종이면적을 체크해준다.
+	 * 전체 종이 배열중에서 체크된곳에서만 cnt를 증가시켜준다.
+	 */
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		int[][] start_black = new int[101][101];
+		int cnt = 0;
+		int start_x=0; int start_y=0;
+		int end_x=0; int end_y=0;
+		int w=0; int h=0;
+		for(int i=0; i<4; i++) {
+			stk = new StringTokenizer(in.readLine());
+			start_x = Integer.parseInt(stk.nextToken());
+			start_y = Integer.parseInt(stk.nextToken());
+			end_x = Integer.parseInt(stk.nextToken());
+			end_y = Integer.parseInt(stk.nextToken());
+			w= end_x-start_x;
+			h= end_y-start_y;
+			for(int y=start_y; y<start_y+h; y++) {
+				for(int x=start_x; x<start_x+w; x++) {
+					start_black[y][x]=1;
+				}
+			}
+		}
+		for (int y = 0; y < 101; y++) {
+			for (int x = 0; x < 101; x++) {
+				if (start_black[y][x]!=0)
+					cnt++;
+			}
+		}
+		sb.append(cnt);
+		out.write(sb.toString());
+		in.close();
+		out.flush();
+		out.close();
+	}
+
+}


### PR DESCRIPTION

1번 문제 직사각형 네개의 합집합의 면적 구하기
	/*
	 * 예전에 과제에서 풀었던 색종이 문제의 용응문제라고 생각했고 풀었음.
	 * 시작 x,y 좌표를 끝 x,y좌표에서 빼주면 가로와 세로의 길이를 구할수 있다.
	 * 1~100까지의 좌표를 담을수 있도록 int[101][101]의 종이 2차원 배열을 만들고 
	 * 그 안에 시작 y,x좌표를 초기값으로 두고 가로와 세로길이만큼 종이면적을 체크해준다.
	 * 전체 종이 배열중에서 체크된곳에서만 cnt를 증가시켜준다.
	 */
2번 문제 수열
	/*
	 * 수열을 담을 배열 혹은 리스트를 담고 
	 * 현재인덱스의 값과 다음인덱스의 값이 >=, <관계 즉 내림차순일 때 정답값++, 혹은 1로 초기화
	 * 오름차순일 때는 <=, > 관계 일때 정답값++, 혹은 1로 초기화 
	 * 내림차순 오름차순을 각각 반복한 뒤에 최대 정닶값을 찾는다.
	 */
3번 문제 참외밭
	/*fail
	 * 북쪽 4번과 남쪽 3번은 y배열, 높이배열에 값을 저장해두고,
	 * 서쪽 2번과 동쪽 1번은 x배열, 가로배열에 값을 저장해둔다.
	 * 높이배열과 가로배열을 오름차순 혹은 내림차순으로 정렬한후 
	 * (max높이*max가로) - (min높이 * min가로)를 하면 참외밭의 넓이가 나온다.
	 * 넓이 * 참외밭 1m^2당 참외수를 곱하면 총 참외수가 나온다.
	 * 
	 * 정답풀이
	 * 각 변의 인덱스 0,1,2,3,4,5를 받고
	 * i번인덱스의 변*i+1의인덱스의 변의 각 사각형을 구한다.
	 * 사각형중 가장 큰 넓이를 지는것을 전체넓이로 두고
	 * 전체 사각형을 제외하고 각 사각형들의 총합은 구해야하는 넓이*3+파인부분의 넓이가 된다
	 * 즉 전체사각형 - ((3*전체사각형)-각 사각형의 총합)을 해주면 굳이 각 변의 위치값이 필요없다.
	 * 최종결과는 위에서 나온값에 참외수를 곱하면 된다.
	 */
//딱지놀이
번호가 높게 부여된 문양일수록 승패우선순위가 높다.
따라서 뒤에서부터 탐색을 시작하여 승패조건을 체크해준다.