### PR TITLE
[3일차] 박기윤_BOJ_월말평가대비_2

### DIFF
--- a/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_박기윤.java
+++ b/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_박기윤.java
@@ -1,0 +1,63 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_14696_딱지놀이_박기윤 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int N = Integer.parseInt(br.readLine());
+		int[][] shape = new int[2][5];
+
+		for (int i = 0; i < N; i++) {
+			boolean aWin = false;
+			boolean isDraw = false;
+			for (int r = 0; r < shape.length; r++)
+				Arrays.fill(shape[r], 0);
+
+			for (int j = 0; j < 2; j++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				int num = Integer.parseInt(st.nextToken());
+				for (int k = 0; k < num; k++) {
+					int tmp = Integer.parseInt(st.nextToken());
+					shape[j][tmp]++;
+				}
+			}
+
+			int shape_num = 4;
+			while (true) {
+				if (shape_num < 1) {
+					isDraw = true;
+					break;
+				}
+				if (shape[0][shape_num] > shape[1][shape_num]) {
+					aWin = true;
+					break;
+				} else if (shape[0][shape_num] < shape[1][shape_num]) {
+					aWin = false;
+					break;
+				} else
+					shape_num--;
+			}
+
+			if (isDraw) {
+				sb.append("D\n");
+				continue;
+			}
+			if (aWin) {
+				sb.append("A\n");
+				continue;
+			} else {
+				sb.append("B\n");
+				continue;
+			}
+		}
+		System.out.println(sb.toString());
+	}
+
+}

--- a/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_박기윤.java
+++ b/day3/BOJ_14696_딱지놀이/BOJ_14696_딱지놀이_박기윤.java
@@ -28,7 +28,6 @@ public class BOJ_14696_딱지놀이_박기윤 {
 					shape[j][tmp]++;
 				}
 			}
-
 			int shape_num = 4;
 			while (true) {
 				if (shape_num < 1) {

--- a/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_박기윤.java
+++ b/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_박기윤.java
@@ -34,7 +34,7 @@ public class BOJ_2477_참외밭_박기윤 {
 		int dirCount[] = new int[5];
 		dirList = new ArrayList<>();
 		lengthList = new ArrayList<>();
-		int long_width = 0; 
+		int long_width = 0;
 		int long_height = 0;
 		for (int i = 0; i < 6; i++) {
 			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
@@ -50,19 +50,14 @@ public class BOJ_2477_참외밭_박기윤 {
 		}
 
 		int smallArea = 0;
-		if (dirCount[1] == 2 && dirCount[3] == 2) {
-			int westIdx = find(2);
-			smallArea = getSmallArea(westIdx);
-		} else if (dirCount[1] == 2 && dirCount[4] == 2) {
-			int SouthIdx = find(3);
-			smallArea = getSmallArea(SouthIdx);
-		} else if (dirCount[2] == 2 && dirCount[4] == 2) {
-			int EastIdx = find(1);
-			smallArea = getSmallArea(EastIdx);
-		} else {
-			int NorthIdx = find(4);
-			smallArea = getSmallArea(NorthIdx);
-		}
+		if (dirCount[1] == 2 && dirCount[3] == 2)
+			smallArea = getSmallArea(find(2));
+		else if (dirCount[1] == 2 && dirCount[4] == 2)
+			smallArea = getSmallArea(find(3));
+		else if (dirCount[2] == 2 && dirCount[4] == 2)
+			smallArea = getSmallArea(find(1));
+		else
+			smallArea = getSmallArea(find(4));
 
 		int bigArea = long_width * long_height;
 		bw.write(Integer.toString((bigArea - smallArea) * K));

--- a/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_박기윤.java
+++ b/day3/BOJ_2477_참외밭/BOJ_2477_참외밭_박기윤.java
@@ -1,0 +1,75 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_2477_참외밭_박기윤 {
+	static ArrayList<Integer> dirList;
+	static ArrayList<Integer> lengthList;
+
+	public static int find(int num) {
+		return dirList.indexOf(num);
+	}
+
+	public static int getSmallArea(int index) {
+		int area = 0;
+		if (index < 3)
+			area = lengthList.get(index + 2) * lengthList.get(index + 3);
+		else if (index == 3)
+			area = lengthList.get(0) * lengthList.get(5);
+		else
+			area = lengthList.get(index - 4) * lengthList.get(index - 3);
+		return area;
+	}
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int K = Integer.parseInt(br.readLine());
+		int dirCount[] = new int[5];
+		dirList = new ArrayList<>();
+		lengthList = new ArrayList<>();
+		int long_width = 0; 
+		int long_height = 0;
+		for (int i = 0; i < 6; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+			int dir = Integer.parseInt(st.nextToken());
+			int length = Integer.parseInt(st.nextToken());
+			dirList.add(dir);
+			lengthList.add(length);
+			dirCount[dir]++;
+			if (dir == 1 || dir == 2)
+				long_width = Math.max(long_width, length);
+			if (dir == 3 || dir == 4)
+				long_height = Math.max(long_height, length);
+		}
+
+		int smallArea = 0;
+		if (dirCount[1] == 2 && dirCount[3] == 2) {
+			int westIdx = find(2);
+			smallArea = getSmallArea(westIdx);
+		} else if (dirCount[1] == 2 && dirCount[4] == 2) {
+			int SouthIdx = find(3);
+			smallArea = getSmallArea(SouthIdx);
+		} else if (dirCount[2] == 2 && dirCount[4] == 2) {
+			int EastIdx = find(1);
+			smallArea = getSmallArea(EastIdx);
+		} else {
+			int NorthIdx = find(4);
+			smallArea = getSmallArea(NorthIdx);
+		}
+
+		int bigArea = long_width * long_height;
+		bw.write(Integer.toString((bigArea - smallArea) * K));
+
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+
+}

--- a/day3/BOJ_2491_수열/BOJ_2491_수열_박기윤.java
+++ b/day3/BOJ_2491_수열/BOJ_2491_수열_박기윤.java
@@ -1,0 +1,51 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_2491_수열_박기윤 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int N = Integer.parseInt(br.readLine());
+		int dp[][] = new int[3][N];
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		for (int i = 0; i < N; i++) {
+			dp[0][i] = Integer.parseInt(st.nextToken());
+		}
+
+		dp[1][0] = 1;
+		dp[2][0] = 1;
+		for (int i = 1; i <= 2; i++) {
+			for (int j = 1; j < N; j++) {
+				if (i == 1) {
+					if (dp[0][j - 1] <= dp[0][j]) {
+						dp[i][j] = dp[i][j - 1] + 1;
+					} else {
+						dp[i][j] = 1;
+					}
+				} else {
+					if (dp[0][j - 1] >= dp[0][j]) {
+						dp[i][j] = dp[i][j - 1] + 1;
+					} else {
+						dp[i][j] = 1;
+					}
+				}
+			}
+		}
+		Arrays.sort(dp[1]);
+		Arrays.sort(dp[2]);
+		bw.write(Integer.toString(Math.max(dp[1][N - 1], dp[2][N - 1])));
+
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+
+}

--- a/day3/BOJ_2669_직사각형네개의합집합면적구하기/BOJ_2669_직사각형네개의합집합의면적구하기_박기윤.java
+++ b/day3/BOJ_2669_직사각형네개의합집합면적구하기/BOJ_2669_직사각형네개의합집합의면적구하기_박기윤.java
@@ -1,0 +1,39 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class BOJ_2669_직사각형네개의합집합의면적구하기_박기윤 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		boolean[][] plane = new boolean[100][100];
+		int count = 0;
+		for (int i = 0; i < 4; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int bottomX = Integer.parseInt(st.nextToken());
+			int bottomY = Integer.parseInt(st.nextToken());
+			int topX = Integer.parseInt(st.nextToken());
+			int topY = Integer.parseInt(st.nextToken());
+			for (int j = bottomX; j < topX; j++) {
+				for (int k = bottomY; k < topY; k++) {
+					if (!plane[j][k]) {
+						plane[j][k]=true;
+						count++;
+					}
+						
+				}
+			}
+		}
+		bw.write(Integer.toString(count));
+		br.close();
+		bw.flush();
+		bw.close();
+	}
+
+}


### PR DESCRIPTION
- BOJ_14696_딱지놀이
    - 별→동그라미→네모→세모 순으로 개수를 확인해서, 특정 도형의 그림을 더 많이 갖고 있는 어린이가 있다면 해당 어린이 승. 세모의 개수까지 동일하다면 무승부 처리.
    
    
- BOJ_2477_참외밭
    - 참외밭으로 가능한 모양은 ㄱ,┏, ┗, ┛4종류이다.
    - 각 모양 별로 입력의 특징이 있다.
        - ㄱ: 방향으로 1,3이 연속적으로 2번 주어진다. (ex) 3-1-3-1
        - ┏: 방향으로 1,4가 연속적으로 2번 주어진다.
        - ┗: 방향으로 2,4가 연속적으로 2번 주어진다.
        - ┛: 방향으로 2,3이 연속적으로 2번 주어진다.
  그렇기 때문에 방향의 입력값으로 참외밭의 모양을 알 수 있다.
    
    - 참외밭의 모양은 항상 큰 사각형에서 작은 사각형을 뺀 모양이다.
    → 참외밭 면적=큰 사각형 면적-작은 사각형 면적
    이를 구하기 위해서는 각 사각형의 가로, 세로 길이를 알아야 한다.
    
    - 큰 사각형
    가로: 동쪽 길이, 서쪽 길이 중 최댓값
    세로: 북쪽 길이, 남쪽 길이 중 최댓값
    
    - 작은 사각형
    참외밭 모양 ㄱ을 예시로 들면
    방향의 입력이 4-2-3-1-3-1이 주어지고 작은 사각형의 가로, 세로 길이는 반드시! 
    가로: 2번(서쪽)으로 주어지는 수의 다음 다음 수→1로 주어지는 수
    세로: 2번(서쪽)으로 주어지는 수의 다음 다음 다음 수→3으로 주어지는 수
    (이건 그림을 그려보면 알 수 있습니다!)
    
    길이를 알아냈으니 각각의 사각형 면적을 구해 큰 사각형에서 작은 사각형을 빼주면 참외밭의 면적이 되고, 여기에 면적 당 자라는 참외의 개수를 구하면 끝.
    
    
- BOJ_2491_수열
    - 이전에 계산한 값을 받아와서 쓸 수 있으므로 `DP`로 해결
    
    3xN 크기의 2차원 배열 dp를 생성
    각 행은 아래와 같은 정보를 담는다.
    0행: 입력값
    1행: 연속해서 커진 길이
    2행: 연속해서 작아진 길이
 
    0행을 오른쪽으로 탐색하면서
    dp[0][j]가 dp[0][j-1]보다 크다면(또는 같다면) dp[1][j]=dp[1][j-1]+1
    작다면 dp[1][j]=1
    dp[0][j]가 dp[0][j-1]보다 작다면(또는 같다면) dp[2][j]=dp[2][j-1]+1
    크다면 dp[2][j]=1
    
    
- BOJ_2669_직사각형 네개의 합집합의 면적 구하기
    직사각형 내부 면적의 중복을 허용하지 않기 위해서, 100x100 boolean 배열을 생성한다. 그리고 입력받은 직사각형 내부를 탐색하며 값이 false라면 true로 바꾸고 count를 1씩 증가시킨다.
    결과적으로 이 count를 출력하면 된다.