### PR TITLE
[14일차] 김선후_BOJ_코테뿌셔_7

### DIFF
--- a/day14/BOJ_1167_트리의지름/BOJ_1167_트리의지름_김선후.java
+++ b/day14/BOJ_1167_트리의지름/BOJ_1167_트리의지름_김선후.java
@@ -1,0 +1,93 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Java_1167 {
+	// 트리의 지름
+//	트리와 bfs dfs 가중치와 관련해서 기억이 흐릿해져서 예전에 라이브 시간때 배웠던 내용들을 복습하는 시간을 가졌습니다.
+//	트리에 존재하는 모든 경로 중 가장 긴것의 길이가 트리의 지름
+//	Solution 1.
+//	1. 각 정점에 대한 인접리스트와 간선가중치를 저장하는 배열을 만든다.
+//	2. dfs 탐색을 수행하여 각 정점에 해당하는 가중치 값들을 계속 더해가며 모든 정점에서의 거리의 최대값을 구한다.
+//	실패 TLE(시간초과) 모든 정점에서 전부 dfs수행이 일어나게 되면서 시간초과가 일어난다.
+//	Solution 2.
+//	1. 가장 긴 지름을 만드는 정점 A와 정점 B가 있다고 가정했을 때, 임의의 노드 1개(여기선 루트정점)에서 가장 먼 정점은 정점 A거나 B다.
+//	2. dfs나 bfs를 수행해서 루트로부터 가장 긴 거리를 지닌 정점 A혹은 B를 찾아낸다.
+//	3. 해당 정점을 기준으로 다시 bfs/dfs를 수행하면 나머지 정점 한개를 구할 수 있다.
+//	메모리 : 98516KB 시간 : 996ms
+//	풀이시간 2시간 14분 13초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N;
+	static class Edge{
+		int to, weight;
+
+		public Edge(int to, int weight) {
+			super();
+			this.to = to;
+			this.weight = weight;
+		}
+		
+	}
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		List<Edge>[] tree = new LinkedList[N+1];
+		int[] dist = new int[N+1];
+		for(int i=0; i<=N; i++) tree[i] = new LinkedList<Edge>();
+		
+		for(int v=0; v<N; v++) {
+			stk=new StringTokenizer(in.readLine());
+			int from = Integer.parseInt(stk.nextToken());
+			while(true) {
+				int to = Integer.parseInt(stk.nextToken());
+				if(to==-1) break;
+				int weight = Integer.parseInt(stk.nextToken());
+				tree[from].add(new Edge(to, weight));
+			}
+		}
+		dist = bfs(tree,1);
+		int start=1;
+		for(int i=2; i<=N; i++) {
+			if(dist[start]<dist[i]) start=i;
+		}
+		dist = bfs(tree, start);
+		Arrays.sort(dist);
+		out.write(dist[N]+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static int[] bfs(List<Edge>[] tree, int start) {
+		boolean[] isVisited = new boolean[N+1];
+		int[] dist = new int[N+1];
+		Queue<Integer> q = new LinkedList<>();
+		q.add(start);
+		isVisited[start]=true;
+		
+		while(!q.isEmpty()) {
+			int v = q.poll();
+			for(Edge e : tree[v]) {
+				int to = e.to;
+				int weight = e.weight;
+				if(!isVisited[to]) {
+					isVisited[to]=true;
+					q.add(to);
+					dist[to]=dist[v]+weight;
+				}
+			}
+		}
+		return dist;
+	}
+
+}

--- a/day14/BOJ_3190_뱀/BOJ_3190_뱀_김선후.java
+++ b/day14/BOJ_3190_뱀/BOJ_3190_뱀_김선후.java
@@ -1,0 +1,114 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Java_3190 {
+	// 뱀
+//	문제 접근법 자체가 어렵지는 않은 문제였으나 시뮬레이션 문제가 늘 그렇듯 생각을 순차적으로 코드로 옮기는 과정이 어려웠습니다.
+//	뱀의 이동과정을 사용하는데 큐와 덱을 사용하면 쉽게 구현할 수 있겠다라는 생각이 들었고
+//	시간별로 종속된 방향전환 값을 담을 수 있는 자료구조가 하나 필요하다고 생각했습니다.
+//	키값에 따른 값을 담는 Map과 기본적인 List 그리고 Que 이렇게 세가지가 떠올랐는데 Map은 다뤄본 경험이 적어서
+//	비교적 익숙한 List를 사용하려고 했으나 기왕 뱀을 구현하는데 Deque를 사용했으니 같은걸 사용하는게 생각하기 더 쉬워보여서 Que를 썼습니다.
+//	덱에 들어간 가장 마지막 데이터가 뱀의 머리 부분이며 가장 처음으로 들어간 데이터가 뱀의 꼬리부분이라는 것만 혼동하지 않으면 비교적 쉽게 풀리는 문제입니다.
+//	Solution 1.
+//	1. 이차원 배열 map을 생성 후 빈공간은 0, 사과는 1, 뱀은 2로 저장
+//	2. 뱀의 머리부터 꼬리까지의 좌표를 덱으로 관리하기 위해서 시간에 따른 방향값을 담은 Dir 클래스와 뱀의 좌표를 담은 Snake 클래스 선언
+//	3. 뱀의 머리가 이동할 때마다 해당 좌표를 덱의 끝부분에 넣어준다.(단 뱀이 이동하려는 좌표가 맵을 벗어나거나 2 SNAKE라면 게임이 끝난다.)
+//	4-1. 사과가 없을 경우 덱의 맨 앞 데이터를 poll하고 해당하는 좌표의 map값을 빈공간 BLANK로 갱신
+//	4-2. 사과가 있을 경우 덱의 맨 뒤 데이터에 추가하고 해당하는 좌표의 맵값을 뱀 SNAKE로 갱신
+//	5. 반복문이 돌아가면서 증가된 시간이 큐에 담겨져있는 첫 데이터의 시간과 같다면 poll한 후에 뱀의 이동방향을 바꾼다.
+	
+//	메모리 : 14640KB 시간 : 132ms
+//	풀이시간 : 1시간 28분 54초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb = new StringBuilder();
+	static int N,K,L,time,currentDir;
+	static int[][] map;
+	static int[] dy = {0,1,0,-1}; //시작 방향 우측
+	static int[] dx = {1,0,-1,0};
+	final static int BLANK = 0;
+	final static int APPLE = 1;
+	final static int SNAKE = 2;
+	static class Dir{
+		int X;
+		String C;
+		public Dir(int x, String c) {
+			super();
+			X = x;
+			C = c;
+		}
+	}
+	static class Snake{
+		int y, x;
+
+		public Snake(int y, int x) {
+			super();
+			this.y = y;
+			this.x = x;
+		}
+		
+	}
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		K = Integer.parseInt(in.readLine());
+		map = new int[N+1][N+1];
+		map[1][1]=SNAKE;
+		for(int apple=0; apple<K; apple++) {
+			stk = new StringTokenizer(in.readLine());
+			int y=Integer.parseInt(stk.nextToken());
+			int x=Integer.parseInt(stk.nextToken());
+			map[y][x]=APPLE;
+		}
+		L=Integer.parseInt(in.readLine());
+		Queue<Dir> dirQue = new LinkedList<>();
+		for(int cmd=0; cmd<L; cmd++) {
+			stk = new StringTokenizer(in.readLine());
+			int X = Integer.parseInt(stk.nextToken());
+			String C = stk.nextToken();
+			dirQue.add(new Dir(X, C));
+		}
+		Deque<Snake> snake = new LinkedList<>();
+		snake.addLast(new Snake(1, 1));
+		while(true) {
+			time++;
+			Snake snakeHead = snake.getLast();
+			int snakeY = snakeHead.y + dy[currentDir%4];
+			int snakeX = snakeHead.x + dx[currentDir%4];
+			if(isBoundary(snakeY,snakeX)) {
+				if(map[snakeY][snakeX]==SNAKE) break;
+				if(map[snakeY][snakeX]==BLANK) {
+					Snake tail = snake.removeFirst();
+					map[tail.y][tail.x]=BLANK;
+				}
+				snake.addLast(new Snake(snakeY, snakeX));
+				map[snakeY][snakeX]=SNAKE;
+			}
+			else break;
+			
+			if(!dirQue.isEmpty() && dirQue.peek().X==time) {
+				Dir changeDir = dirQue.poll();
+				if(changeDir.C.equals("L")) currentDir += 3;
+				else currentDir +=1;
+			}
+		}
+		out.write(time+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static boolean isBoundary(int snakeY, int snakeX) {
+		if(1<=snakeY && 1<=snakeX && snakeY<=N && snakeX<=N) return true;
+		return false;
+	}
+
+}


### PR DESCRIPTION
1번 트리의 지름 / 메모리 : 98516KB 시간 : 996ms 성공 풀이시간 2시간 14분 13초

트리와 bfs dfs 가중치와 관련해서 기억이 흐릿해져서 예전에 라이브 시간때 배웠던 내용들을 복습하는 시간을 가졌습니다.
트리에 존재하는 모든 경로 중 가장 긴것의 길이가 트리의 지름
* Solution 1.
1. 각 정점에 대한 인접리스트와 간선가중치를 저장하는 배열을 만든다.
2. dfs 탐색을 수행하여 각 정점에 해당하는 가중치 값들을 계속 더해가며 모든 정점에서의 거리의 최대값을 구한다.
실패 TLE(시간초과) 모든 정점에서 전부 dfs수행이 일어나게 되면서 시간초과가 일어난다.
* Solution 2.
1. 가장 긴 지름을 만드는 정점 A와 정점 B가 있다고 가정했을 때, 임의의 노드 1개(여기선 루트정점)에서 가장 먼 정점은 정점 A거나 B다.
2. dfs나 bfs를 수행해서 루트로부터 가장 긴 거리를 지닌 정점 A혹은 B를 찾아낸다.
3. 해당 정점을 기준으로 다시 bfs/dfs를 수행하면 나머지 정점 한개를 구할 수 있다.

2번 뱀 / 메모리 14640KB 시간 132ms 성공 풀이시간 : 1시간 28분 54초
문제 접근법 자체가 어렵지는 않은 문제였으나 시뮬레이션 문제가 늘 그렇듯 생각을 순차적으로 코드로 옮기는 과정이 어려웠습니다.
뱀의 이동과정을 나타내는데 큐와 덱을 사용하면 쉽게 구현할 수 있겠다라는 생각이 들었고 시간별로 종속된 방향전환 값을 담을 수 있는 자료구조가 하나 필요하다고 생각했습니다.
키값에 따른 값을 담는 Map과 기본적인 List 그리고 Que 이렇게 세가지가 떠올랐는데 Map은 다뤄본 경험이 적어서,
비교적 익숙한 List를 사용하려고 했으나 기왕 뱀을 구현하는데 Deque를 사용했으니 같은걸 사용하는게 생각하는데 있어서 더 쉬워보여서 Que를 썼습니다.
덱에 들어간 가장 마지막 데이터가 뱀의 머리 부분이며 가장 처음으로 들어간 데이터가 뱀의 꼬리부분이라는 것만 혼동하지 않으면 비교적 쉽게 풀리는 문제입니다.
* Solution 1.
1. 이차원 배열 map을 생성 후 빈공간은 0, 사과는 1, 뱀은 2로 저장
2. 뱀의 머리부터 꼬리까지의 좌표를 덱으로 관리하기 위해서 시간에 따른 방향값을 담은 Dir 클래스와 뱀의 좌표를 담은 Snake 클래스 선언
3. 뱀의 머리가 이동할 때마다 해당 좌표를 덱의 끝부분에 넣어준다.(단 뱀이 이동하려는 좌표가 맵을 벗어나거나 2 SNAKE라면 게임이 끝난다.)
4. 
   4.1. 사과가 없을 경우 덱의 맨 앞 데이터를 poll하고 해당하는 좌표의 map값을 빈공간 BLANK로 갱신
   4.2. 사과가 있을 경우 덱의 맨 뒤 데이터에 추가하고 해당하는 좌표의 맵값을 뱀 SNAKE로 갱신
5. 반복문이 돌아가면서 증가된 시간이 큐에 담겨져있는 첫 데이터의 시간과 같다면 poll한 후에 뱀의 이동방향을 바꾼다.