### PR TITLE
[16일차] 김선후_BOJ_코테뿌셔_9

### DIFF
--- a/day16/BOJ_15685_드래곤커브/BOJ_15685_드래곤커브_김선후.java
+++ b/day16/BOJ_15685_드래곤커브/BOJ_15685_드래곤커브_김선후.java
@@ -1,0 +1,152 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Java_15685 {
+	// 드래곤커브
+	// 입력으로 드래곤커브의 시작 좌표, 시작 방향, 세대가 주어진다.
+	// 이전 세대에서 시계방향으로 90도 만큼 회전한 모양이 다음 세대가 된다.
+	// 방향 0 1 2 3 우 상 좌 하 (방향+1)%4=반시계방향 90도 회전
+	// 주어진 예시에서 n세대인 드래곤 커브의 방향리스트는
+	// 세대 0 [0]
+	// 세대 1 [0, 1]
+	// 세대 2 [0, 1, 2, 1]
+	// 세대 3 [0, 1, 2, 1, 2, 3, 2, 1]
+	// 이전 세대의 방향 리스트를 역순으로 탐색한뒤 (방향+1)%4의 방향이 다음 선분을 그리게 되는 방향이 된다.
+	// Solution 1.
+	// 1. 드래곤커브의 정보를 입력받는다.
+	// 2. 드래곤커브의 개수만큼 맵에 점들을 표시한다.
+	// 2-1. 0세대는 자기 자신의 좌표와 시작좌표+시작방향좌표를 찍는다.
+	// 2-2. 1세대부터는 이전 세대의 방향좌표 리스트를 역순으로 탐색하며 세대수만큼 반복해서 점을 찍는다.
+	// 3. 맵을 탐색하며 점이 찍혀있는 부분이 네 꼭짓점 전체를 이루고 있으면 정답카운트를 증가시킨다.
+	// 메모리 : 14408KB 시간 : 140ms
+	// 추가 내용 메모리 : 14436 시간 : 132ms
+	// 풀이시간 1시간 4분 06초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N, ans;
+	static boolean[][] map = new boolean[101][101];
+	static int[] dy = { 0, -1, 0, 1 };
+	static int[] dx = { 1, 0, -1, 0 };
+	// 문제를 푼 이후 추가 내용
+	static int x1 = 100, x2 = 0, y1 = 100, y2 = 0; // 최대 범위 설정
+
+	static class DragonCurve {
+		int y, x, dir, gen;
+
+		public DragonCurve(int y, int x, int dir, int gen) {
+			super();
+			this.y = y;
+			this.x = x;
+			this.dir = dir;
+			this.gen = gen;
+		}
+
+	}
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		DragonCurve[] dragonCurveList = new DragonCurve[N];
+		for (int i = 0; i < N; i++) {
+			stk = new StringTokenizer(in.readLine());
+			int x = Integer.parseInt(stk.nextToken());
+			int y = Integer.parseInt(stk.nextToken());
+			int dir = Integer.parseInt(stk.nextToken());
+			int gen = Integer.parseInt(stk.nextToken());
+			
+			setRange(y, x);
+			dragonCurveList[i] = new DragonCurve(y, x, dir, gen);
+		}
+		for (int i = 0; i < N; i++)
+			fillMap(dragonCurveList[i]);
+		ans = count();
+		out.write(ans + "");
+		out.flush();
+		out.close();
+		in.close();
+	}
+
+//	private static int count() {
+//		int cnt = 0;
+//		for (int y = 0; y < 100; y++) {
+//			for (int x = 0; x < 100; x++) {
+//				if (!map[y][x])
+//					continue;
+//				if (map[y][x] && map[y][x + 1] && map[y + 1][x] && map[y + 1][x + 1])
+//					cnt++;
+//			}
+//		}
+//		return cnt;
+//	}
+
+	private static int count() {
+		int cnt = 0;
+		for(int y=y1; y<y2; y++) {
+			for(int x=x1; x<x2; x++) {
+				if(!map[y][x]) continue;
+				if(map[y][x] && map[y][x+1] && map[y+1][x] && map[y+1][x+1]) cnt++;
+			}
+		}
+		return cnt;
+	}
+//	private static void fillMap(DragonCurve DragonCurve) {
+//		int gen = DragonCurve.gen;
+//		ArrayList<Integer> dirList = new ArrayList<Integer>();
+//		int ny = DragonCurve.y + dy[DragonCurve.dir];
+//		int nx = DragonCurve.x + dx[DragonCurve.dir];
+//		map[DragonCurve.y][DragonCurve.x] = true;
+//		map[ny][nx] = true;
+//		dirList.add(DragonCurve.dir);
+//		int ndir;
+//		while (gen-- > 0) {
+//			for (int i = dirList.size() - 1; i >= 0; i--) {
+//				ndir = (dirList.get(i) + 1) % 4;
+//				ny += dy[ndir];
+//				nx += dx[ndir];
+//				map[ny][nx] = true;
+//				dirList.add(ndir);
+//			}
+//		}
+//	}
+	private static void fillMap(DragonCurve dragonCurve) {
+		int gen = dragonCurve.gen;
+		ArrayList<Integer> dirList = new ArrayList<Integer>();
+		int ny = dragonCurve.y + dy[dragonCurve.dir];
+		int nx = dragonCurve.x + dx[dragonCurve.dir];
+		setRange(ny,nx);
+		map[dragonCurve.y][dragonCurve.x] = true;
+		map[ny][nx] = true;
+		dirList.add(dragonCurve.dir);
+		int ndir;
+		while (gen-- > 0) {
+			for (int i = dirList.size() - 1; i >= 0; i--) {
+				ndir = (dirList.get(i) + 1) % 4;
+				ny += dy[ndir];
+				nx += dx[ndir];
+				setRange(ny,nx);
+				map[ny][nx] = true;
+				dirList.add(ndir);
+			}
+		}
+	}
+
+	private static void setRange(int y, int x) {
+		if (x < x1)
+			x1 = x;
+		if (x > x2)
+			x2 = x;
+		if (y < y1)
+			y1 = y;
+		if (y > y2)
+			y2 = y;
+	}
+
+}

--- a/day16/BOJ_17951_흩날리는시험지속에서내평점이느껴진거야/BOJ_17951_흩날리는시험지속에서내평점이느껴진거야_김선후_실패및구글링이해불가.java
+++ b/day16/BOJ_17951_흩날리는시험지속에서내평점이느껴진거야/BOJ_17951_흩날리는시험지속에서내평점이느껴진거야_김선후_실패및구글링이해불가.java
@@ -1,0 +1,68 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_17951 {
+	// 흩날리는 시험지 속에서 내 평점이 느껴진거야
+	// 문제풀이 실패 
+	//처음에는 순열, 조합, 부분집합 문제라고 생각했으나 문제의 조건을 자세히 살펴보면 시험지의 순서는 이미 정해져 있다.
+	//이 문제에서 구해야할 것은 그룹별 최소점수의 최댓값이다.
+	//완탐을 돌리면 최악의 경우 O(10만 * 10만)이 나오므로 사용해선 안된다는 것 까진 알 수 있었다.
+	//log의 시간효율을 지니는 접근법을 사용해야하는 것 까지는 알 수 있었다.
+	//풀이시간 2시간 13분 12초 1시간30분동안 못풀었을때 도무지 방법자체를 찾을수없어서 구글링함.
+	
+	//문제풀이 실패 후 구글링 풀이
+	//Solution 1.
+	//문제를 이진 탐색으로 접근하였을때 이 문제에서의 mid가 의미해야 하는 것은 그룹별 최대 점수다.
+	//이 그룹별 최대 점수를 넘어갈 경우에만 그룹을 나눈다.
+	//0에서부터 모든 시험지의 점수 합까지 이진 탐색을 돌리면서 차례차례 더해가면서 정해놓은 그룹별 최대점수보다 커지면 구간을 나눈다.
+	//나누어진 구간의 수가 K개 이상이라면 문제의 조건을 만족하므로 그룹 목표최소점을 그룹별 최대점수에서 1만큼 더한값으로 바꾼다.
+	//나누어진 구간의 수가 K개 미만이라면 문제의 조건을 만족하지 못하므로(그룹 목표최고점이 너무 높아서) 그룹 목표최고점을 그룹별 최대점수에서 1만큼 줄인 값으로 바꾼다.
+	//그룹 목표최소점이 그룹목표 최고점보다 커질때까지 반복한다.
+	//해설을 보고도 완벽하게 이해하지 못하였다.
+	//mid의 기준이 왜 그룹별 최대 점수이며 반복문의 조건이 왜 저렇게 되는지를 이해하지 못하겠다
+	//누군가 해설을 해주었으면 좋겠다..
+	//메모리 : 23228 시간 : 300ms
+	static BufferedReader in=new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N,K,groupLowScore=0,groupHighScore=0;
+	static int[] testScore;
+	public static void main(String[] args) throws IOException {
+		stk = new StringTokenizer(in.readLine());
+		N = Integer.parseInt(stk.nextToken());
+		K = Integer.parseInt(stk.nextToken());
+		testScore = new int[N];
+		stk = new StringTokenizer(in.readLine());
+		for(int i=0; i<N; i++) {
+			testScore[i] = Integer.parseInt(stk.nextToken());
+			groupHighScore += testScore[i];
+		}
+		while(groupLowScore<=groupHighScore) {
+			int mid = (groupLowScore+groupHighScore)/2;
+			int groupSum=0;
+			int groupCnt=0;
+			for(int k=0; k<N; k++) {
+				groupSum+=testScore[k];
+				if(groupSum>=mid) {
+					groupCnt++;
+					groupSum=0;
+				}
+			}
+//			System.out.println("groupLowScore : "+groupLowScore+" groupHighScore : "+groupHighScore+" groupCnt : "+groupCnt+" mid : "+mid);
+			if(groupCnt>=K) groupLowScore = mid+1;
+			else groupHighScore = mid-1;
+		}
+		out.write(groupHighScore+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+
+}


### PR DESCRIPTION
1번 문제 드래곤 커브 
메모리 : 14408KB 시간 : 140ms
추가 내용 메모리 : 14436 시간 : 132ms
풀이시간 1시간 4분 06초
* 입력으로 드래곤커브의 시작 좌표, 시작 방향, 세대가 주어진다.
* 이전 세대에서 시계방향으로 90도 만큼 회전한 모양이 다음 세대가 된다.
* 방향 0 1 2 3 우 상 좌 하 (방향+1)%4=반시계방향 90도 회전
* 주어진 예시에서 n세대인 드래곤 커브의 방향리스트는
 세대 0 [0]
 세대 1 [0, 1]
 세대 2 [0, 1, 2, 1]
 세대 3 [0, 1, 2, 1, 2, 3, 2, 1]
 * 이전 세대의 방향 리스트를 역순으로 탐색한뒤 (방향+1)%4의 방향이 다음 선분을 그리게 되는 방향이 된다.
 Solution 1.
 1. 드래곤커브의 정보를 입력받는다.
 2. 드래곤커브의 개수만큼 맵에 점들을 표시한다.
    2-1. 0세대는 자기 자신의 좌표와 시작좌표+시작방향좌표를 찍는다.
    2-2. 1세대부터는 이전 세대의 방향좌표 리스트를 역순으로 탐색하며 세대수만큼 반복해서 점을 찍는다.
 3. 맵을 탐색하며 점이 찍혀있는 부분이 네 꼭짓점 전체를 이루고 있으면 정답카운트를 증가시킨다.
 
2번 문제 흩날리는 시험지 속에서 내 평점이 느껴진거야
* 문제풀이 실패 
* 처음에는 순열, 조합, 부분집합 문제라고 생각했으나 문제의 조건을 자세히 살펴보면 시험지의 순서는 이미 정해져 있다.
* 이 문제에서 구해야할 것은 그룹별 최소점수의 최댓값이다.
* 완탐을 돌리면 최악의 경우 O(10만 * 10만)이 나오므로 사용해선 안된다는 것 까진 알 수 있었다.
* log의 시간효율을 지니는 접근법을 사용해야하는 것 까지는 알 수 있었다.
풀이시간 2시간 13분 12초
1시간30분동안 못풀었을때 도무지 방법자체를 찾을수없어서 구글링함.

* 문제풀이 실패 후 구글링 풀이
Solution 1.
1. 문제를 이진 탐색으로 접근하였을때 이 문제에서의 mid가 의미해야 하는 것은 그룹별 최대 점수다.
이 그룹별 최대 점수를 넘어갈 경우에만 그룹을 나눈다.
2. 0에서부터 모든 시험지의 점수 합까지 이진 탐색을 돌리면서 차례차례 더해가면서 정해놓은 그룹별 최대점수보다 커지면 구간을 나눈다.
3. 
   3-1. 나누어진 구간의 수가 K개 이상이라면 문제의 조건을 만족하므로 그룹 목표최소점을 그룹별 최대점수에서 1만큼 더한값으로 바꾼다.
   3-2. 나누어진 구간의 수가 K개 미만이라면 문제의 조건을 만족하지 못하므로(그룹 목표최고점이 너무 높아서) 그룹 목표최고점을 그룹별 최대점수에서 1만큼 줄인 값으로 바꾼다.
4. 그룹 목표최소점이 그룹목표 최고점보다 커질때까지 반복한다.
* 해설을 보고도 완벽하게 이해하지 못하였다.
* mid의 기준이 왜 그룹별 최대 점수이며 반복문의 조건이 왜 저렇게 되는지를 이해하지 못하겠다.
*누군가 해설을 해주었으면 좋겠다..
메모리 : 23228 시간 : 300ms