### PR TITLE
[17일차] 김선후_BOJ_코테뿌셔_10

### DIFF
--- a/day17/BOJ_14501_퇴사/BOJ_14501_퇴사_김선후.java
+++ b/day17/BOJ_14501_퇴사/BOJ_14501_퇴사_김선후.java
@@ -1,0 +1,57 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_14501 {
+	// 퇴사
+	//문제를 풀기전에는 다들 어렵다고 하셔서 겁을 먹고 문제를 읽어보았으나 dp라고 생각하면 해당문제를 풀기위한 점화식이 도저히 생각이 나지 않아서 다른 방법을 생각했습니다.
+	//입력값이 N 1~15까지이기에 이문제는 재귀로 풀면 쉽게 풀 수 있지 않을까하는 생각이 들었습니다. 
+	//최악의 경우 재귀가 15번밖에 반복되지 않으므로 스택오버플로우의 위험이 상대적으로 덜해보였습니다.
+	//또한 해당문제에서 결국 구해야하는 것은 '누적'수익이며 조건에 따라서 해당일을 선택하는가 안하는가를 따지는 순열?조합?부분집합?의 문제가 아닌가하는점이 보였습니다.
+	//무언가를 누적하는 개념에서는 대개 depth로 표현이 가능하므로 dfs문제로서 문제를 접근해보았습니다.
+	//Solution 1.
+	//1. 해당일수에 종속되는 수행일수와 수익금을 나타내는 2차배열 dayByTP 선언 0은 수행일수 1은 수익금
+	//2. dfs 수행
+	//2-1. 기저조건은 누적일수가 N(목표일수)가 될경우 누적수익금을 반환해야 합니다
+	//2-2. N(목표일)이 지금까지의 누적일수에서 해당누적일수에 해당하는 수행일수를 더한값보다 크거나 같다면 작업에 착수할 수 있으므로 누적일수와 누적수익금을 추가하고 dfs호출
+	//2-3. 작업에 착수할 수 없다면(혹은 선택하지 않는다면) 누적일수에 +1일만 더하고 dfs호출
+	//메모리 14312KB 시간 132ms
+	//풀이 시간 10분 18초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb= new StringBuilder();
+	static int N,ans;
+	static int[][] dayByTP;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		dayByTP = new int[N][2]; //[i][0] 수행일수 [i][1] 수익금
+		for(int i=0; i<N; i++) {
+			stk = new StringTokenizer(in.readLine());
+			dayByTP[i][0] = Integer.parseInt(stk.nextToken());
+			dayByTP[i][1] = Integer.parseInt(stk.nextToken());
+		}
+		ans=Integer.MIN_VALUE;
+		dfs(0,0);
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static void dfs(int stackDay, int stackPay) {
+		if(stackDay==N) {
+			ans = Math.max(ans, stackPay);
+			return;
+		}
+		//목표퇴사일 >= 누적일수+해당일의 수행일수 (해당 일에 작업을 수행할수있음)
+		if(N>=dayByTP[stackDay][0]+stackDay) dfs(stackDay+dayByTP[stackDay][0],stackPay+dayByTP[stackDay][1]);
+		//해당일에 작업을 수행하지 않고(선택하지 않고) 다음 일수로 넘어감
+		dfs(stackDay+1, stackPay);
+	}
+
+}

--- a/day17/BOJ_2262_토너먼트만들기/BOJ_2262_토너먼트만들기_김선후.java
+++ b/day17/BOJ_2262_토너먼트만들기/BOJ_2262_토너먼트만들기_김선후.java
@@ -1,0 +1,54 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Java_2262 {
+	// 토너먼트 만들기
+	// 처음에 문제 예시를 보고 B예시의 답이 11이라는 점에서 아무리 봐도 10이 나와야 하지 않은지 의문이 들어서 문제에 대해서 파악하는데 오래걸렸습니다.
+	// 1시간동안 문제에 대한 명확한 접근법을 찾을수 없어서 알고리즘 분류를 보고서 그리드로 풀어야 한다는 것을 알았습니다.
+	// 처음에는 모든 선수들을 3명씩 끊은후 중앙에서 양쪽의 차이를 비교한 후 부전승으로 오를 선수를 결정한 뒤 랭킹차를 더해나가는 식으로 접근을 해보았으나
+	// 양쪽 선수들과의 랭킹차이가 같은 경우의 예외처리를 두는것이 복잡해서 해결하지 못하였습니다.
+	// 문제에서 주어진 절차를 생각해보았을때 매칭이 된 두 선수 중에서 랭킹이 더 높은(숫자가 낮은) 선수가 무조건 승리합니다.
+	// 선수들이 매칭되는 순서는 변하지 않는 경우 랭킹이 가장 높은 선수들순서대로 토너먼트 순서를 진행한다고 한다면 양쪽에서 랭킹 차이가 적은 선수들을 선택해도
+	// 갈수록 점차 이전 선수보다 더 랭킹이 낮은 선수들과 경기가 진행되므로 랭킹 차가 점점 더 커집니다.
+	// 반대로 랭킹이 가장 낮은 선수부터 토너먼트 순서를 진행시킨다면 랭킹이 낮은 선수는 반드시 경기에서 승리하지 못하기 때문에 그 선수를 남은 선수목록에서 제외시키며 진행할수 있게됩니다.
+	//Solution 1.
+	//1. 선수들을 순서대로 담을 수 있는 리스트 선언
+	//2. 가장 랭킹이 낮은 선수의 랭크를 담을 변수 lastRank에 선언된선수수(=가장낮은랭킹)를 저장
+	//3. 리스트를 탐색하기위한 인덱스 변수에 랭킹이 가장 낮은 선수의 인덱스를 저장
+	//4. 반복문을 돌면서 현재 가장 랭킹이 낮은선수의 위치에 따른 매칭선수와의 랭킹차를 구한 후 정답값에 더하기
+	//5. 패배한 선수 제외 후 가장 낮은 랭킹 조정.
+	//6. 최종적으로 나온 정답값 출력
+	// 풀이시간 2시간 52분
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb= new StringBuilder();
+	static int N,ans,lastRank;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		ArrayList<Integer> memberList = new ArrayList<Integer>();
+		stk = new StringTokenizer(in.readLine());
+		for(int n=0; n<N; n++) memberList.add(Integer.parseInt(stk.nextToken()));
+		lastRank = N;
+		for(int n=0; n<N-1; n++) {
+			int idx = memberList.indexOf(lastRank);
+			if(idx==0) ans+= memberList.get(idx) - memberList.get(idx+1); //가장 낮은 랭킹선수가 첫번째순서
+			else if(idx==memberList.size()-1) ans+=memberList.get(idx)-memberList.get(idx-1); //가장 낮은 랭킹선수가 마지막 순서
+			else ans+=Math.min(memberList.get(idx)-memberList.get(idx+1), memberList.get(idx)-memberList.get(idx-1)); //가장 낮은 랭킹선수가 가운데
+			memberList.remove(idx); //패배한 선수 제외
+			lastRank--; //남은 선수중 가장 랭킹 낮은선수 랭킹조정
+		}
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+
+}

--- a/day17/BOJ_2579_계단오르기/BOJ_2579_계단오르기_김선후.java
+++ b/day17/BOJ_2579_계단오르기/BOJ_2579_계단오르기_김선후.java
@@ -1,0 +1,45 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_2579 {
+	// 계단 오르기
+	//1. 한칸씩 연속으로 오를수없다.
+	//2. n번째 계단의 값은 두가지의 경우로 나뉜다.
+	//2-1. n번째 계단의 점수+n-1번째 계단의 점수+n-3까지의 점수 (2->1->n)로 뛰는경우
+	//2-2. n번째 계단의 점수+n-2까지의 점수	(2->n)로 뛰는 경우
+	//두 경우에서 더 큰값으로 n번째까지의 누적점수를 갱신해준다.
+	//!!!. 반례 N이 2 미만인 경우가 존재하므로 세번째 누적점수를 초기화하기 위한 조건식이 꼭 들어가야한다. 여기서 10분넘게 날렸다 ㅠ
+	//Solution 1.
+	//1. n번째까지의 누적점수와 현재 도착한 계단의 점수를 담을 수 있는 2차원 배열 dp[N][2]를 선언한다. [0] 계단점수 [1] 누적점수
+	//2. 1번째 2번째 3번째의 dp값을 초기화하고 배열인덱스 4부터 반복문을 실행한다.
+	//3. n번째 계단까지 도달하는 두가지의 경우의 수 중 더 큰값으로 해당 n번째계단까지의 누적점수를 갱신한다.
+	//4. 반복문이 n번까지 돌고 나온후의 n번째 dp배열의 누적점수값을 정답값으로 출력한다.
+	//메모리 14296KB 시간 140ms
+	//풀이시간 30분
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer stk;
+	static StringBuilder sb= new StringBuilder();
+	static int N;
+	static int[][] dp;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		dp = new int[N+1][2];
+		for(int i=0; i<N; i++) dp[i][0]=Integer.parseInt(in.readLine());
+		dp[0][1]=dp[0][0];			//1번째
+		dp[1][1]=dp[0][0]+dp[1][0];	//2번째
+		if(N>=2) dp[2][1]=Math.max(dp[0][0], dp[1][0])+dp[2][0];	//3번째
+		for(int n=3; n<=N; n++) dp[n][1]=Math.max(dp[n-3][1]+dp[n-1][0], dp[n-2][1])+dp[n][0];
+		out.write(dp[N-1][1]+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+
+}


### PR DESCRIPTION
1번 문제 토너먼트 만들기  
메모리 14416KB 시간 132ms
풀이시간 2시간 52분
* 처음에 문제 예시를 보고 B예시의 답이 11이라는 점에서 아무리 봐도 10이 나와야 하지 않은지 의문이 들어서 문제에 대해서 파악하는데 오래걸렸습니다.
* 1시간동안 문제에 대한 명확한 접근법을 찾을수 없어서 알고리즘 분류를 보고서 그리드로 풀어야 한다는 것을 알았습니다.
* 처음에는 모든 선수들을 3명씩 끊은후 중앙에서 양쪽의 차이를 비교한 후 부전승으로 오를 선수를 결정한 뒤 랭킹차를 더해나가는 식으로 접근을 해보았으나 양쪽 선수들과의 랭킹차이가 같은 경우의 예외처리를 두는것이 복잡해서 해결하지 못하였습니다.
* 문제에서 주어진 절차를 생각해보았을때 매칭이 된 두 선수 중에서 랭킹이 더 높은(숫자가 낮은) 선수가 무조건 승리합니다.
* 선수들이 매칭되는 순서는 변하지 않는 경우 랭킹이 가장 높은 선수들순서대로 토너먼트 순서를 진행한다고 한다면 양쪽에서 랭킹 차이가 적은 선수들을 선택해도 갈수록 점차 이전 선수보다 더 랭킹이 낮은 선수들과 경기가 진행되므로 랭킹 차가 점점 더 커집니다.
* 반대로 랭킹이 가장 낮은 선수부터 토너먼트 순서를 진행시킨다면 랭킹이 낮은 선수는 반드시 경기에서 승리하지 못하기 때문에 그 선수를 남은 선수목록에서 제외시키며 진행할수 있게됩니다.

Solution 1.
1. 선수들을 순서대로 담을 수 있는 리스트 선언
2. 가장 랭킹이 낮은 선수의 랭크를 담을 변수 lastRank에 선언된선수수(=가장낮은랭킹)를 저장
3. 리스트를 탐색하기위한 인덱스 변수에 랭킹이 가장 낮은 선수의 인덱스를 저장
4. 반복문을 돌면서 현재 가장 랭킹이 낮은선수의 위치에 따른 매칭선수와의 랭킹차를 구한 후 정답값에 더하기
5. 패배한 선수 제외 후 가장 낮은 랭킹 조정.
6. 최종적으로 나온 정답값 출력

2번 문제 계단 오르기
메모리 14296KB 시간 140ms
풀이시간 30분
*   1-0. 한칸씩 연속으로 오를수없다.
*   2-0. n번째 계단의 값은 두가지의 경우로 나뉜다.
*   2-1. n번째 계단의 점수+n-1번째 계단의 점수+n-3까지의 점수 (2->1->n)로 뛰는경우
*   2-2. n번째 계단의 점수+n-2까지의 점수	(2->n)로 뛰는 경우
*   두 경우에서 더 큰값으로 n번째까지의 누적점수를 갱신해준다.
*   !!!. 반례 N이 2 미만인 경우가 존재하므로 세번째 누적점수를 초기화하기 위한 조건식이 꼭 들어가야한다. 여기서 10분넘게 날렸다 ㅠ

Solution 1.
1. n번째까지의 누적점수와 현재 도착한 계단의 점수를 담을 수 있는 2차원 배열 dp[N][2]를 선언한다. [0] 계단점수 [1] 누적점수
2. 1번째 2번째 3번째의 dp값을 초기화하고 배열인덱스 4부터 반복문을 실행한다.
3. n번째 계단까지 도달하는 두가지의 경우의 수 중 더 큰값으로 해당 n번째계단까지의 누적점수를 갱신한다.
4. 반복문이 n번까지 돌고 나온후의 n번째 dp배열의 누적점수값을 정답값으로 출력한다.

3번 문제 퇴사
메모리 14312KB 시간 132ms
풀이 시간 10분 18초
* 문제를 풀기전에는 다들 어렵다고 하셔서 겁을 먹고 문제를 읽어보았으나 dp라고 생각하면 해당문제를 풀기위한 점화식이 도저히 생각이 나지 않아서 다른 방법을 생각했습니다.
* 입력값이 N 1~15까지이기에 이문제는 재귀로 풀면 쉽게 풀 수 있지 않을까하는 생각이 들었습니다. 
* 최악의 경우 재귀가 15번밖에 반복되지 않으므로 스택오버플로우의 위험이 상대적으로 덜해보였습니다.
* 또한 해당문제에서 결국 구해야하는 것은 '누적'수익이며 조건에 따라서 해당일을 선택하는가 안하는가를 따지는 순열?조합?부분집합?의 문제가 아닌가하는점이 보였습니다.
* 무언가를 누적하는 개념에서는 대개 depth로 표현이 가능하므로 dfs문제로서 문제를 접근해보았습니다.

Solution 1.
1. 해당일수에 종속되는 수행일수와 수익금을 나타내는 2차배열 dayByTP 선언 0은 수행일수 1은 수익금
2. dfs 수행
   2-1. 기저조건은 누적일수가 N(목표일수)가 될경우 누적수익금을 반환해야 합니다
   2-2. N(목표일)이 지금까지의 누적일수에서 해당누적일수에 해당하는 수행일수를 더한값보다 크거나 같다면 작업에 착수할 수 있으므로 누적일수와 누적수익금을 추가하고 dfs호출
   2-3. 작업에 착수할 수 없다면(혹은 선택하지 않는다면) 누적일수에 +1일만 더하고 dfs호출
