### PR TITLE
[20일차] 김선후_BOJ_코테뿌셔_13

### DIFF
--- a/day20/BOJ_17140_이차원배열과연산/BOJ_17140_이차원배열과연산_김선후_fail.java
+++ b/day20/BOJ_17140_이차원배열과연산/BOJ_17140_이차원배열과연산_김선후_fail.java
@@ -1,0 +1,71 @@
+package fail;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_17140_fail {
+	//이차원 배열과 연산
+	//풀이 실패 설계과정 자체는 짜낼 수 있었으나 HashMap에 대한 이해 부족으로 원하는 기능을 사용하지 못하여 구현을 못하였습니다.
+	//중복된 숫자의 횟수를 세기 위해서는 hash가 사용될 수 있다는 걸 지문을 읽으면서 염두에 두었습니다.
+	//그 중에서도 HashMap을 사용하기에 정말 알맞은 문제라는 생각이 들었고 key값을 숫자 value를 중첩횟수로 두면 될것 같았습니다.
+	//등장 횟수 기준 오름차순은 value 기준 HashMap을 오름차순으로 정렬합니다.
+	//HashMap에 넣을 때 0은 제외시킵니다. 만약 열 정렬 과정에서 앞의 행보다 뒤의 행의 길이가 길 경우 0을 만나서 종료하는 조건이 걸립니다.
+	//Solution 1.
+	//1. 가장 초기의 배열 ans = 3*3의 2차원 배열
+	//2. 1초마다 연산수행 시간(정답)을 담을 time변수 필요
+	//3. if(행 길이 >= 열 길이) 가로줄 개수 >= 세로줄 개수일때 R정렬 else C정렬
+	//   3-1. 0무시
+	//   3-2. 하나의 행 또는 열에서 숫자의 등장 횟수를 카운트 
+	//   3-3. 등장 횟수 기준 오름차순 정렬
+	//   3-4. 등장 횟수가 같으면 숫자 기준 오름차순 정렬
+	//   3-5. 숫자->등장 횟수 순서대로 배열에 한칸씩 갱신
+	//   3-6. 배열 갱신시 행 혹은 열의 길이가 100이 넘어가면 나머지는 버린다.
+	//4. 100초 안에 ans[R][C] == K 를 만족할 때 까지 연산 수행 만족 시 time 출력
+	//5. if(time>100) -1출력
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int R,C,K,time,finalAns;
+	static int[][] ans;
+	static final int MAX = 100;
+	static int COL=3, ROW=3;
+	public static void main(String[] args) throws IOException {
+		input();
+		solve();
+	}
+	private static void solve() {
+		while(ans[R][C] != K) {
+			if(++time>100) break;
+			if(ROW>=COL) calcRow();
+			else calcCol();
+		}
+		finalAns = time>100?-1:time;
+	}
+	private static void calcCol() {
+		// TODO Auto-generated method stub
+		
+	}
+	private static void calcRow() {
+		// TODO Auto-generated method stub
+		
+	}
+	private static void input() throws IOException {
+		stk = new StringTokenizer(in.readLine());
+		R = Integer.parseInt(stk.nextToken());
+		C = Integer.parseInt(stk.nextToken());
+		K = Integer.parseInt(stk.nextToken());
+		ans = new int[MAX][MAX];
+		for(int y=0; y<COL; y++) {
+			stk = new StringTokenizer(in.readLine());
+			for(int x=0; x<ROW; x++) {
+				ans[y][x] = Integer.parseInt(stk.nextToken());
+			}
+		}
+	}
+
+}

--- a/day20/BOJ_1890_점프/BOJ_1890_점프_김선후.java
+++ b/day20/BOJ_1890_점프/BOJ_1890_점프_김선후.java
@@ -1,0 +1,70 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Java_1890 {
+	//점프
+	//메모리 14368KB 시간 136ms
+	//풀이시간 1시간 2분
+	//지문을 읽으면서 dfs로 해결을 할 생각을 했다가 답이 최악 2^63-1이 나오므로 일반적인 dfs로는 시간초과가 확정.
+	//dp와 dfs를 섞어서 사용하여 중복 구간에 대한 연산을 지울 필요가 있음(메모이제이션)
+	//Solution 1.
+	//1. 2차원 배열 map에 입력을 받고 같은 배열크기의 long타입 dp를 초기화한다.(미연결상태 표시를 위해 -1로 초기화)
+	//2. 초기좌표로부터 dfs 연산 수행
+	//   2-1. dp[y][x]의 방문처리를 위해 0으로 초기화
+	//   2-2. 다음에 갈수있는 좌표는 현재좌표의 값을 각 y,x좌표에 더한 값이다.
+	//   2-3. 만약 ny, nx가 N(배열 크기)보다 커지면 0을 반환한다.(즉 해당좌표의 dfs연산값은 0(이동실패)이다)
+	//   2-4. 만약 아래나 옆으로 갈수 있다면 현재 연결 처리된 dp[y][x]와 dp[y][x]+dfs(다음좌표) 중 큰것을 dp[y][x]로 갱신한다.
+	//   2-5. dp[y][x]를 반환한다.
+	//   2-6. 만약 dp[y][x]가 이미 연결된 곳이라면 dp[y][x]를 반환한다.
+	//   2-7. 만약 y x의 좌표가 끝점이라면 1을 반환한다. (dfs 더하기 연산에서 끝까지 연결된 경우만 더해주는 경우)
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N;
+	static int[][] map;
+	static long[][] dp;
+	static long ans;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		input();
+		ans = dfs(1,1);
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static long dfs(int y, int x) {
+		if(dp[y][x] != -1) return dp[y][x];
+		if(y==N && x==N) return 1;
+		dp[y][x]=0;
+		int ny = y+map[y][x];
+		int nx = x+map[y][x];
+		if(ny>N && nx>N) return 0;
+		if(ny<=N) dp[y][x] = Math.max(dp[y][x], dp[y][x]+dfs(ny, x));
+		if(nx<=N) dp[y][x] = Math.max(dp[y][x], dp[y][x]+dfs(y,nx));
+		return dp[y][x];
+	}
+	private static void input() throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		map = new int[N+1][N+1];
+		for(int y=1; y<=N; y++) {
+			stk = new StringTokenizer(in.readLine());
+			for(int x=1; x<=N; x++) {
+				map[y][x] = Integer.parseInt(stk.nextToken());
+			}
+		}
+		dp = new long[N+1][N+1];
+		for(int y=1; y<=N; y++) {
+			for(int x=1; x<=N; x++) {
+				dp[y][x]=-1;
+			}
+		}
+	}
+
+}

--- a/day20/BOJ_2110_공유기설치/BOJ_2110_공유기설치_김선후.java
+++ b/day20/BOJ_2110_공유기설치/BOJ_2110_공유기설치_김선후.java
@@ -1,0 +1,74 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Java_2110 {
+	// 공유기 설치
+	//메모리 28988KB 시간 300ms
+	//풀이시간 32분 53초
+	//입력값이 최대 10억(=일반적인 완전탐색에만 평균 1초)가 걸리므로 브루트포스는 배제해야 할 것 같았습니다.
+	//문제에서 원하는 결과를 도출하기 위해서는 C개의 한정된 공유기 개수로 현재 입력된 전체 길이에서 거리 간격을 최대 몇으로 할 수 있는가였습니다.
+	//공유기의 최대거리 설정은 미정이고 가상의 최대거리(목표)를 설정하는 거라면 이진탐색으로 접근하는 문제가 아닌가하는 생각을 떠올리기까지가 핵심이었던 문제였습니다.
+	//Soulution 1.
+	//1. 집의 개수와 공유기의 개수를 입력 받은 후 집의 x좌표를 담아놓을 1차원 배열 houseX를 생성 및 초기화.
+	//2. 이진탐색을 위해 houseX 오름차순 정렬
+	//3. houseX 배열의 최소 길이(가장가까운 다음좌표와의 거리는 1)와 최대 길이(맨끝좌표-맨처음좌표)를 초기화.
+	//4. 최대거리 구하기 위한 반복문 실행
+	//   4-1. 공유기 설치 간격 가상목표 설정 mid = (최소길이+최대길이)/2
+	//   4-2. 공유기 설치 좌표 받고 공유기 개수 증가 (처음은 맨 첫 좌표)
+	//   4-3. N개의 집을 탐색하며 목표거리에 해당 집의 좌표-이전에 공유기를 설치한 좌표로 거리를 구하기
+	//   4-4. 목표거리가 가상목표 mid보다 크거나 같을 경우에만 공유기를 설치 후 공유기 설치좌표 갱신
+	//   4-5. 지금까지 설치된 공유기 개수가 C이상이면 최소거리 재설정 후 정답값 갱신
+	//   4-6. C미만이면 최대거리 재설정
+	//   4-7. 반복문이 종료되고 가장 마지막으로 갱신된 정답값이 최대간격거리
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N,C,ans;
+	static int[] houseX;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		input();
+		binarySearch();
+	}
+	private static void binarySearch() throws IOException {
+		Arrays.sort(houseX);
+		int minDist=1;
+		int maxDist=houseX[N-1]-houseX[0];
+		while(minDist<=maxDist) {
+			int mid = (minDist+maxDist)/2;
+			int frontHouseX=houseX[0];
+			int cnt=1;
+			for(int x=0; x<N; x++) {
+				int distance = houseX[x]-frontHouseX;
+				if(distance>=mid) {
+					cnt++;
+					frontHouseX = houseX[x];
+				}
+			}
+			if(cnt>=C) {
+				minDist = mid+1;
+				ans=mid;
+			}
+			else maxDist = mid-1;
+		}
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static void input() throws NumberFormatException, IOException {
+		stk = new StringTokenizer(in.readLine());
+		N=Integer.parseInt(stk.nextToken());
+		C=Integer.parseInt(stk.nextToken());
+		houseX = new int[N];
+		for(int x=0; x<N; x++) houseX[x] = Integer.parseInt(in.readLine());
+	}
+
+}


### PR DESCRIPTION
1번 문제 점프
메모리 14368KB 시간 136ms
풀이시간 1시간 2분

* 지문을 읽으면서 dfs로 해결을 할 생각을 했다가 답이 최악 2^63-1이 나오므로 일반적인 dfs로는 시간초과가 확정.
* dp와 dfs를 섞어서 사용하여 중복 구간에 대한 연산을 지울 필요가 있음(메모이제이션)

Solution 1.

1. 2차원 배열 map에 입력을 받고 같은 배열크기의 long타입 dp를 초기화한다.(미연결상태 표시를 위해 -1로 초기화)
2. 초기좌표로부터 dfs 연산 수행
   2-1. dp[y][x]의 방문처리를 위해 0으로 초기화
   2-2. 다음에 갈수있는 좌표는 현재좌표의 값을 각 y,x좌표에 더한 값이다.
   2-3. 만약 ny, nx가 N(배열 크기)보다 커지면 0을 반환한다.(즉 해당좌표의 dfs연산값은 0(이동실패)이다)
   2-4. 만약 아래나 옆으로 갈수 있다면 현재 연결 처리된 dp[y][x]와 dp[y][x]+dfs(다음좌표) 중 큰것을 dp[y][x]로 갱신한다.
   2-5. dp[y][x]를 반환한다.
   2-6. 만약 dp[y][x]가 이미 연결된 곳이라면 dp[y][x]를 반환한다.
   2-7. 만약 y x의 좌표가 끝점이라면 1을 반환한다. (dfs 더하기 연산에서 끝까지 연결된 경우만 더해주는 경우)

2번 문제 공유기 설치
메모리 28988KB 시간 300ms
풀이시간 32분 53초

* 입력값이 최대 10억(=일반적인 완전탐색에만 평균 1초)가 걸리므로 브루트포스는 배제해야 할 것 같았습니다.
* 문제에서 원하는 결과를 도출하기 위해서는 C개의 한정된 공유기 개수로 현재 입력된 전체 길이에서 거리 간격을 최대 몇으로 할 수 있는가였습니다.
* 공유기의 최대거리 설정은 미정이고 가상의 최대거리(목표)를 설정하는 거라면 이진탐색으로 접근하는 문제가 아닌가하는 생각을 떠올리기까지가 핵심이었던 문제였습니다.

Soulution 1.

1. 집의 개수와 공유기의 개수를 입력 받은 후 집의 x좌표를 담아놓을 1차원 배열 houseX를 생성 및 초기화.
2. 이진탐색을 위해 houseX 오름차순 정렬
3. houseX 배열의 최소 길이(가장가까운 다음좌표와의 거리는 1)와 최대 길이(맨끝좌표-맨처음좌표)를 초기화.
4. 최대거리 구하기 위한 반복문 실행
   4-1. 공유기 설치 간격 가상목표 설정 mid = (최소길이+최대길이)/2
   4-2. 공유기 설치 좌표 받고 공유기 개수 증가 (처음은 맨 첫 좌표)
   4-3. N개의 집을 탐색하며 목표거리에 해당 집의 좌표-이전에 공유기를 설치한 좌표로 거리를 구하기
   4-4. 목표거리가 가상목표 mid보다 크거나 같을 경우에만 공유기를 설치 후 공유기 설치좌표 갱신
   4-5. 지금까지 설치된 공유기 개수가 C이상이면 최소거리 재설정 후 정답값 갱신
   4-6. C미만이면 최대거리 재설정
   4-7. 반복문이 종료되고 가장 마지막으로 갱신된 정답값이 최대간격거리

3번 문제 이차원 배열과 연산
풀이 실패 
설계과정 자체는 짜낼 수 있었으나 HashMap에 대한 이해 부족으로 원하는 기능을 사용하지 못하여 구현을 못하였습니다.

* 중복된 숫자의 횟수를 세기 위해서는 hash가 사용될 수 있다는 걸 지문을 읽으면서 염두에 두었습니다.
* 그 중에서도 HashMap을 사용하기에 정말 알맞은 문제라는 생각이 들었고 key값을 숫자 value를 중첩횟수로 두면 될것 같았습니다.
* 등장 횟수 기준 오름차순은 value 기준 HashMap을 오름차순으로 정렬합니다.
* HashMap에 넣을 때 0은 제외시킵니다. 만약 열 정렬 과정에서 앞의 행보다 뒤의 행의 길이가 길 경우 0을 만나서 종료하는 조건이 걸립니다.

Solution 1.

1. 가장 초기의 배열 ans = 3*3의 2차원 배열
2. 1초마다 연산수행 시간(정답)을 담을 time변수 필요
3. if(행 길이 >= 열 길이) 가로줄 개수 >= 세로줄 개수일때 R정렬 else C정렬
   3-1. 0무시
   3-2. 하나의 행 또는 열에서 숫자의 등장 횟수를 카운트 
   3-3. 등장 횟수 기준 오름차순 정렬
   3-4. 등장 횟수가 같으면 숫자 기준 오름차순 정렬
   3-5. 숫자->등장 횟수 순서대로 배열에 한칸씩 갱신
   3-6. 배열 갱신시 행 혹은 열의 길이가 100이 넘어가면 나머지는 버린다.
4. 100초 안에 ans[R][C] == K 를 만족할 때 까지 연산 수행 만족 시 time 출력
5. if(time>100) -1출력