### PR TITLE
[23일차] 김선후_BOJ_코테뿌셔_16

### DIFF
--- a/day23/BOJ_17142_연구소3/BOJ_17142_연구소3_김선후.java
+++ b/day23/BOJ_17142_연구소3/BOJ_17142_연구소3_김선후.java
@@ -1,0 +1,142 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Java_17142 {
+	// 연구소 3
+	//메모리 40580KB 시간 268ms
+	// 조합과 bfs 혼합 문제였습니다.
+	// 조합을 사용해서 활성시킬 바이러스들의 좌표를 큐에 입력하고
+	//한번의 depth(1초를 한사이클)내에서 들어간 해당 큐의 개수만큼 사방탐색을 진행하는 문제.
+	// 빈 공간 없이 처음부터 전부 벽과 바이러스로 이루어진 반례가 존재하므로 빈공간을 체크하는 변수 필요
+	//Solution 1.
+	//1. 입력을 받으면서 빈 공간의 개수 (blank)와 바이러스의 좌표(viruses)를 저장
+	//2. 만약 빈공간이 없다면 ans값은 0이 되야한다.
+	//3. 전체 바이러스 리스트중에서 M개의 바이러스를 선택하여 모든 조합의 경우를 탐색하여 바이러스 확산
+	//4. 선택한 바이러스를 큐로 옮긴 후 bfs를 사용하여 확산 수행
+	//5. 탐색을 하며 빈 공간인지 확인 후 빈 공간(blankSpace)감소 주의 할 점은 blank는 static 변수이기에 항상 초기화 시킬 변수 필요
+	//6. 마찬가지로 isVisited(방문체크) 배열 또한 확산 메서드가 실행될때마다 초기화 필요
+	//7. 1초의 한 사이클(각 depth단계)마다 입력된 큐만큼만 사방탐색을 할 필요가 있음. (시간단위 구분이 존재하기 때문)
+	//8. 한 사이클의 큐에 있는 모든 바이러스의 확산이 완료되면 time 증가.
+	//9. 빈 칸이 더 이상 존재 하지 않는 경우 최단시간 갱신.
+	//10. 만약 현재까지 갱신된 최단 시간보다 현 수행과정 중의 최단시간이 더 오래 걸린다면 더 이상 검사할 필요가 없다.
+	// 풀이시간 58분 14초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N,M,ans,blank;
+	static int[][] map;
+	static boolean[][] isVisited;
+	static int[] dy = {-1,1,0,0};
+	static int[] dx = {0,0,-1,1};
+	static class Virus{
+		int y, x;
+
+		public Virus(int y, int x) {
+			super();
+			this.y = y;
+			this.x = x;
+		}
+		
+	}
+	static List<Virus> viruses = new ArrayList<>();
+	static Virus[] selectedVirus;
+	public static void main(String[] args) throws IOException {
+		input();
+		if(blank==0) {
+			ans=0;
+			sb.append(ans);
+		}
+		else {
+			virusComb(0,0);
+			sb.append(ans==Integer.MAX_VALUE?-1:ans);
+		}
+		out.write(sb.toString());
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static void virusComb(int depth, int start) {
+		if(depth==M) {
+			virusSpread();
+			return;
+		}
+		for(int i=start; i<viruses.size(); i++) {
+			selectedVirus[depth] = viruses.get(i);
+			virusComb(depth+1, i+1);
+		}
+	}
+	private static void virusSpread() {
+		Queue<Virus> q = new LinkedList<>();
+		isVisited = new boolean[N][N];
+		for(Virus select : selectedVirus) {
+			q.add(select);
+			isVisited[select.y][select.x]=true;
+		}
+		
+		int time=0;
+		int blankSpace = blank;
+		while(!q.isEmpty()) {
+			int nowDepth = q.size();
+			for(int i=0; i<nowDepth; i++) {
+				Virus current = q.poll();
+				for(int d=0; d<4; d++) {
+					int ny = current.y+dy[d];
+					int nx = current.x+dx[d];
+					
+					if(isBoundary(ny,nx)) continue;
+					if(isPossible(ny,nx)) continue;
+					
+					if(map[ny][nx]==0) {
+						blankSpace--;
+					}
+					isVisited[ny][nx]=true;
+					q.add(new Virus(ny, nx));
+				}
+			}
+			time++;
+			if(time >= ans) return;
+			if(blankSpace <= 0) ans = time;
+		}
+	}
+	
+	private static boolean isPossible(int ny, int nx) {
+		if(isVisited[ny][nx] || map[ny][nx]==1) return true;
+		return false;
+	}
+	private static boolean isBoundary(int ny, int nx) {
+		if(ny<0 || nx<0 || ny>=N || nx>=N) return true;
+		return false;
+	}
+	private static void input() throws IOException {
+		stk = new StringTokenizer(in.readLine());
+		N = Integer.parseInt(stk.nextToken());
+		M = Integer.parseInt(stk.nextToken());
+		
+		map = new int[N][N];
+		isVisited = new boolean[N][N];
+		selectedVirus = new Virus[M];
+		
+		for(int y=0; y<N; y++) {
+			stk = new StringTokenizer(in.readLine());
+			for(int x=0; x<N; x++) {
+				map[y][x]=Integer.parseInt(stk.nextToken());
+				if(map[y][x]==0) blank++;
+				else if(map[y][x]>1) viruses.add(new Virus(y, x));
+			}
+		}
+//		System.out.println(blank);
+		ans = Integer.MAX_VALUE;
+	}
+
+}

--- a/day23/BOJ_1922_네트워크연결/BOJ_1922_네트워크연결_김선후.java
+++ b/day23/BOJ_1922_네트워크연결/BOJ_1922_네트워크연결_김선후.java
@@ -1,0 +1,93 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Java_1922 {
+	// 네트워크 연결
+	//메모리 46775KB 시간 488ms
+	// 가중치가 존재하며 모든 간선을 최소 비용으로 연결 해야할 때 적용할 알고리즘은 MST가 있다.
+	// 또한 a b 정점과 b c 정점이 연결 상태라면 a c 가 연결 상태가 된다는 것은
+	// b의 최상위 부모가 a이고 b와 c가 연결 상태라면 c의 부모는 a로 바꾸는 식으로 연결상태를 표현
+	// 유니온파인드를 응용할 수 있는 문제다.
+	//Solution 1.
+	//1. 모든 정점을 최소비용으로 연결
+	//2. 크루스칼 알고리즘 적용
+	//3. 가중치를 기준으로 오름차순 정렬 (우선순위 큐 적용)
+	//4. 가중치가 가장 낮은 두 정점(가장 먼저 빠져 나온 큐) 선택
+	//5. 두 정점의 부모가 같은지 다른지 판별 후 다르면 같은 부모로 결합(union-find)
+	//6. union-find가 사용될때마다 해당 간선을 선택했다는 의미로 해당 간선의 가중치를 증가시킨다.
+	//7. 모든 큐가 빌 경우 나오게 된 가중치의 합이 최소비용이 된다(우선순위 큐로 오름차순을 하였기때문)
+	//풀이시간 21분 1초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N, M, ans;
+	static PriorityQueue<Edge> tree;
+	static class Edge implements Comparable<Edge>{
+		int from, to, weight;
+
+		public Edge(int from, int to, int weight) {
+			super();
+			this.from = from;
+			this.to = to;
+			this.weight = weight;
+		}
+
+		@Override
+		public int compareTo(Edge o) {
+			return this.weight-o.weight;
+		}
+		
+	}
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		input();
+		MST();
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static void MST() {
+		int[] parent = new int[N+1];
+		
+		for(int i=1; i<=N; i++) parent[i]=i;
+		
+		while(!tree.isEmpty()) {
+			Edge current = tree.poll();
+			
+			int parentFrom = find(parent, current.from);
+			int parentTo = find(parent, current.to);
+			if(parentFrom != parentTo) {
+				parent[parentTo] = parentFrom;
+				
+				ans += current.weight;				
+			}
+		}
+	}
+	private static int find(int[] parent, int x) {
+		if(parent[x]==x) return x;
+		return parent[x] = find(parent, parent[x]);
+	}
+	private static void input() throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		M = Integer.parseInt(in.readLine());
+		tree = new PriorityQueue<>();
+		while(M--> 0) {
+			stk = new StringTokenizer(in.readLine());
+			
+			int from = Integer.parseInt(stk.nextToken());
+			int to = Integer.parseInt(stk.nextToken());
+			int weight = Integer.parseInt(stk.nextToken());
+			
+			tree.add(new Edge(from, to, weight));
+		}
+	}
+
+}

--- a/day23/BOJ_2512_예산/BOJ_2512_예산_김선후.java
+++ b/day23/BOJ_2512_예산/BOJ_2512_예산_김선후.java
@@ -1,0 +1,76 @@
+package anystep;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Java_2512 {
+	// 예산
+	//메모리 16960KB 시간 192ms
+	//기본적인 탐색을 진행한다면 최악 탐색을 한번 하는데만 10억=1초가 걸린다. => 일반적인 완탐 문제가 아님.
+	//가상의 목표 점수를 구해야 함. => 이진탐색
+	//Solution 1.
+	//1. 입력을 받는다.
+	//2. 이진 탐색을 위해서 지방배열을 오름차순으로 정렬.
+	//3. 모든 지방의 합이 주어진 상한선보다 작거나 같다면 지방예산 최댓값을 그대로 출력
+	//4. 3의 조건을 만족하지 않다면 이진 탐색 수행
+	//5. 지방예산이 목표예산보다 크다면 기준값을 현재 총합값에 더한다.
+	//6. 그게 아니라면 현재 지방예산을 현재 총합값에 더한다.
+	//7. 현재 총합값이 상한선보다 크다면 최대예산을 목표예산-1로 갱신 후 이진탐색 재수행
+	//8. 현재 총합값이 상한선보다 작다면 최소예산을 목표예산+1로 갱신 후 이진탐색 재수행
+	//9. 현재 총합값이 상한선과 같다면 최종 출력값으로 출력
+	//10. 이진탐색이 전부 끝난다면 마지막으로 갱신된 최대 예산값이 최종 출력값이다.
+	//풀이시간 32분 14초
+	static BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringBuilder sb = new StringBuilder();
+	static StringTokenizer stk;
+	static int N,M,ans;
+	static int[] locate;
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		input();
+		binarySearch();
+		out.write(ans+"");
+		out.flush();
+		out.close();
+		in.close();
+	}
+	private static void binarySearch() {
+		int sum=0;
+		for(int b : locate) sum+=b;
+		if(sum<=M) ans=locate[N-1];
+		else {
+			int low=0;
+			int high = M;
+			while(low<=high) {
+				int mid=(low+high)/2;
+				int total=0;
+				for(int i=0; i<N; i++) {
+					if(locate[i]>mid) total += mid;
+					else total += locate[i];
+				}
+				if(total>M) high = mid-1;
+				else if(total<M) low = mid+1;
+				else {
+					ans=mid;
+					return;
+				}
+			}
+			ans=high;
+			return;
+		}
+	}
+	private static void input() throws NumberFormatException, IOException {
+		N = Integer.parseInt(in.readLine());
+		locate = new int[N];
+		stk = new StringTokenizer(in.readLine());
+		for(int i=0; i<N; i++) locate[i]=Integer.parseInt(stk.nextToken());
+		M = Integer.parseInt(in.readLine());
+		Arrays.sort(locate);
+	}
+
+}


### PR DESCRIPTION
1번 문제 네트워크 연결
메모리 46775KB 시간 488ms
* 가중치가 존재하며 모든 간선을 최소 비용으로 연결 해야할 때 적용할 알고리즘은 MST가 있다.
* 또한 a b 정점과 b c 정점이 연결 상태라면 a c 가 연결 상태가 된다는 것은 b의 최상위 부모가 a이고 b와 c가 연결 상태라면 c의 부모는 a로 바꾸는 식으로 연결상태를 표현
* 유니온파인드를 응용할 수 있는 문제다.

Solution 1.

1. 모든 정점을 최소비용으로 연결
2. 크루스칼 알고리즘 적용
3. 가중치를 기준으로 오름차순 정렬 (우선순위 큐 적용)
4. 가중치가 가장 낮은 두 정점(가장 먼저 빠져 나온 큐) 선택
5. 두 정점의 부모가 같은지 다른지 판별 후 다르면 같은 부모로 결합(union-find)
6. union-find가 사용될때마다 해당 간선을 선택했다는 의미로 해당 간선의 가중치를 증가시킨다.
7. 모든 큐가 빌 경우 나오게 된 가중치의 합이 최소비용이 된다(우선순위 큐로 오름차순을 하였기때문)

풀이시간 21분 1초

2번 문제 예산
메모리 16960KB 시간 192ms
* 기본적인 탐색을 진행한다면 최악 탐색을 한번 하는데만 10억=1초가 걸린다. => 일반적인 완탐 문제가 아님.
* 가상의 목표 점수를 구해야 함. => 이진탐색

Solution 1.

1. 입력을 받는다.
2. 이진 탐색을 위해서 지방배열을 오름차순으로 정렬.
3. 모든 지방의 합이 주어진 상한선보다 작거나 같다면 지방예산 최댓값을 그대로 출력
4. 3의 조건을 만족하지 않다면 이진 탐색 수행
5. 지방예산이 목표예산보다 크다면 기준값을 현재 총합값에 더한다.
6. 그게 아니라면 현재 지방예산을 현재 총합값에 더한다.
7. 현재 총합값이 상한선보다 크다면 최대예산을 목표예산-1로 갱신 후 이진탐색 재수행
8. 현재 총합값이 상한선보다 작다면 최소예산을 목표예산+1로 갱신 후 이진탐색 재수행
9. 현재 총합값이 상한선과 같다면 최종 출력값으로 출력
10. 이진탐색이 전부 끝난다면 마지막으로 갱신된 최대 예산값이 최종 출력값이다.

풀이시간 32분 14초

3번 문제 연구소 3
메모리 40580KB 시간 268ms
* 조합과 bfs 혼합 문제였습니다.
* 조합을 사용해서 활성시킬 바이러스들의 좌표를 큐에 입력하고
한번의 depth(1초를 한사이클)내에서 들어간 해당 큐의 개수만큼 사방탐색을 진행하는 문제.
* 빈 공간 없이 처음부터 전부 벽과 바이러스로 이루어진 반례가 존재하므로 빈공간을 체크하는 변수 필요

Solution 1.

1. 입력을 받으면서 빈 공간의 개수 (blank)와 바이러스의 좌표(viruses)를 저장
2. 만약 빈공간이 없다면 ans값은 0이 되야한다.
3. 전체 바이러스 리스트중에서 M개의 바이러스를 선택하여 모든 조합의 경우를 탐색하여 바이러스 확산
4. 선택한 바이러스를 큐로 옮긴 후 bfs를 사용하여 확산 수행
5. 탐색을 하며 빈 공간인지 확인 후 빈 공간(blankSpace)감소 주의 할 점은 blank는 static 변수이기에 항상 초기화 시킬 변수 필요
6. 마찬가지로 isVisited(방문체크) 배열 또한 확산 메서드가 실행될때마다 초기화 필요
7. 1초의 한 사이클(각 depth단계)마다 입력된 큐만큼만 사방탐색을 할 필요가 있음. (시간단위 구분이 존재하기 때문)
8. 한 사이클의 큐에 있는 모든 바이러스의 확산이 완료되면 time 증가.
9. 빈 칸이 더 이상 존재 하지 않는 경우 최단시간 갱신.
10. 만약 현재까지 갱신된 최단 시간보다 현 수행과정 중의 최단시간이 더 오래 걸린다면 더 이상 검사할 필요가 없다.
 
풀이시간 58분 14초